### PR TITLE
ENH: Add infrastructure for building the python package using GitHub Actions

### DIFF
--- a/.github/scripts/cibw_before_build.sh
+++ b/.github/scripts/cibw_before_build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -ev
+
+if [[ $RUNNER_OS == "Linux" ]]; then
+    # Some of the VTK modules use this library, and auditwheel will
+    # complain if it can't find it. We will remove it from the wheel
+    # after the repair is complete.
+    yum install libXcursor-devel -y
+
+    # Make sure this is removed before every build, so we always
+    # get the correct one.
+    rm -rf $VTK_WHEEL_SDK_INSTALL_PATH
+fi

--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -ev
+
+#### Install cibuildwheel ####
+pip install cibuildwheel
+
+if [[ $RUNNER_OS == "macOS" ]]; then
+    # VTK is expecting the xcode path to be slightly different.
+    # Specifically, the VTK::RenderingOpenGL2 imported target seems
+    # to expect the absolute path to the OpenGL library to match.
+    ln -s /Applications/Xcode_13.1.app/ /Applications/Xcode-13.1.app
+fi

--- a/.github/scripts/linux_repair_wheel.py
+++ b/.github/scripts/linux_repair_wheel.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+import glob
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+from utils import change_dir, unzip_file
+
+"""
+This script does the following:
+
+1. Copy all vtk modules into the wheel
+2. Run auditwheel repair
+3. Remove anything that wasn't there before the repair
+
+This is done so that we can get proper tags on the wheel, without the
+RPATHs or contents of the wheel being affected.
+
+Note: if we make the VTK modules visible to auditwheel by modifying the
+LD_LIBRARY_PATH, auditwheel copies them into the project, but modifies
+the RPATHs of our libraries. We do not want auditwheel to modify the
+RPATHs, so we copy the VTK modules in ourselves.
+
+It would be great if auditwheel, at some point, allowed us to add tags
+to the wheel *without* repairing it...
+"""
+
+if len(sys.argv) < 3:
+    sys.exit('Usage: <script> <wheel_path> <output_dir>')
+
+wheel_path = sys.argv[1]
+output_dir = sys.argv[2]
+
+wheel_sdk_path = os.getenv('VTK_WHEEL_SDK_INSTALL_PATH')
+if wheel_sdk_path is None:
+    raise Exception('VTK_WHEEL_SDK_INSTALL_PATH must be set')
+
+vtkmodules_glob_pattern = Path(wheel_sdk_path) / 'build/*/vtkmodules/*.so'
+vtkmodules = glob.glob(str(vtkmodules_glob_pattern))
+if not vtkmodules:
+    raise Exception(f'Failed to find vtkmodules at: {vtkmodules_glob_pattern}')
+
+with unzip_file(wheel_path) as unpacked_path:
+    # Take a snapshot of the directory contents. After the wheel repair, we
+    # will remove all files except for these.
+    with change_dir(unpacked_path):
+        contents_snapshot = list(Path().rglob('*'))
+
+        # Find the path to the RECORD file
+        record_glob = list(Path().glob('*.dist-info/RECORD'))
+        if len(record_glob) != 1:
+            raise Exception('Failed to find RECORD file')
+
+        record_path = record_glob[0]
+
+        # Read in the RECORD file. We will write it back out after the repair.
+        with open(record_path, 'r') as rf:
+            record_text = rf.read()
+
+    # Copy the vtkmodules in
+    destination = Path(unpacked_path) / 'vtkmodules'
+    for f in vtkmodules:
+        output = destination / Path(f).name
+        if output.exists():
+            # Don't overwrite any files
+            continue
+
+        shutil.copyfile(f, output)
+
+# Now, perform the auditwheel repair
+cmd = ['auditwheel', 'repair', wheel_path, '-w', output_dir]
+subprocess.check_call(cmd)
+
+# There should now be a wheel in the wheelhouse
+output = glob.glob(f'{output_dir}/*.whl')
+if len(output) != 1:
+    raise Exception(f'Failed to find wheel in `{output_dir}`')
+
+output_wheel = output[0]
+
+# Now, remove all newly added files
+with unzip_file(output_wheel) as unpacked_path:
+    with change_dir(unpacked_path):
+        for item in Path().rglob('*'):
+            if item not in contents_snapshot:
+                if item.is_dir():
+                    shutil.rmtree(item)
+                else:
+                    item.unlink()
+
+        # Replace the RECORD file with the old one
+        with open(record_path, 'w') as wf:
+            wf.write(record_text)

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -1,0 +1,38 @@
+from contextlib import contextmanager
+import os
+from pathlib import Path
+import shutil
+import zipfile
+
+
+@contextmanager
+def unzip_file(zip_path, unpack_path=None):
+    # This will unzip the file while inside the context, and re-zip it
+    # afterwards, which allows the caller to modify the contents
+
+    if unpack_path is None:
+        unpack_path = str(Path('__tmp_unzip_file_unpack').resolve())
+
+    with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+        zip_ref.extractall(unpack_path)
+
+    try:
+        yield unpack_path
+    finally:
+        name = shutil.make_archive(zip_path, 'zip', unpack_path)
+        shutil.rmtree(unpack_path)
+        if name.endswith('.zip'):
+            Path(name).rename(name[:-4])
+
+
+@contextmanager
+def change_dir(path):
+    # Temporarily change the directory to the path. When the context ends,
+    # the path will be changed back.
+
+    origin = Path.cwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(origin)

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,0 +1,115 @@
+name: Build Wheels
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+       - '*'
+  pull_request:
+    branches:
+      - main
+
+  workflow_dispatch:
+
+env:
+  # Only support 64-bit CPython >= 3.7
+  # VTK does not currently build python 3.8 arm64 wheels, so skip it too
+  CIBW_SKIP: "cp27-* cp35-* cp36-* cp37-* pp* *-manylinux_i686 *-musllinux_* *-win32 cp38-macosx_arm64"
+
+  # Need to match the version used by VTK
+  CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.10
+
+  # In the Linux docker container, install the wheel SDKs to this location
+  CIBW_ENVIRONMENT_LINUX: VTK_WHEEL_SDK_INSTALL_PATH=/vtk-wheel-sdk
+
+  # NOTE: cross-compilation is not currently working for us for arm64.
+  # We are going to turn it off and build them manually until GitHub Actions
+  # makes arm64 runners available.
+  # Build both x86_64 and arm64 (through cross-compilation) wheels on Mac
+  # CIBW_ARCHS_MACOS: x86_64 arm64
+
+  # VTK already fixes the rpaths, so we can skip this step for MacOS
+  CIBW_REPAIR_WHEEL_COMMAND_MACOS:
+
+  # On Linux, we only need auditwheel to add the tags to the wheel.
+  # Unfortunately, auditwheel currently requires us to repair the wheel to
+  # add the tags, even though we do not need to repair the wheel.
+  # Thus, we need to set everything up for a wheel repair (including placing
+  # the VTK libraries in `vtkmodules`, where they are expected to be at
+  # runtime), perform the wheel repair, and then remove the added libraries.
+  # Then the tags will have been added.
+  CIBW_REPAIR_WHEEL_COMMAND_LINUX: .github/scripts/linux_repair_wheel.py {wheel} {dest_dir}
+
+  # Pass these variables into the Linux docker containers
+  CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS VTK_WHEEL_SDK_INSTALL_PATH
+
+  # Run this before every build
+  CIBW_BEFORE_BUILD: bash .github/scripts/cibw_before_build.sh
+
+  CIBW_TEST_COMMAND: >
+    pip install -r {package}/Testing/Python/requirements.txt &&
+    pytest -v {package}/Testing/Python
+
+  CIBW_TEST_COMMAND_WINDOWS: >
+    pip install -r {package}/Testing/Python/requirements.txt &&
+    pytest -v {package}/Testing/Python &&
+    pyinstaller --noconfirm --distpath {package}/pyi/dist --workpath {package}/pyi/build --specpath {package}/Testing/Python {package}/Testing/Python/pyi_test_program.py &&
+    {package}/pyi/dist/pyi_test_program/pyi_test_program.exe
+
+
+# Use bash by default for the run command
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b # v4.6.0
+        name: Install Python
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: bash .github/scripts/install.sh
+
+      - name: Build wheels
+        run: cibuildwheel --output-dir wheelhouse
+
+      - name: Upload skbuild if an error occurred (for debugging)
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: skbuild
+          path: ${{ github.workspace }}/_skbuild
+
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          path: ./wheelhouse/*.whl
+
+  upload_pypi:
+    needs: build_wheels
+    name: Upload wheels to PyPI
+    runs-on: ubuntu-latest
+    # upload to PyPI on every tag push
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
+    steps:
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@0bf742be3ebe032c25dd15117957dc15d0cfc38d # v1.8.5
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/FetchFromUrl.cmake
+++ b/FetchFromUrl.cmake
@@ -1,0 +1,14 @@
+include(FetchContent)
+
+# Before calling this, the following variables must be defined:
+# FETCH_FROM_URL_PROJECT_NAME - a unique name for the project
+# FETCH_FROM_URL_URL - the URL from which to download the project
+# FETCH_FROM_URL_INSTALL_LOCATION - the location to unpack the project
+
+FetchContent_Populate(${FETCH_FROM_URL_PROJECT_NAME}
+  URL         ${FETCH_FROM_URL_URL}
+  SOURCE_DIR  ${FETCH_FROM_URL_INSTALL_LOCATION}
+  QUIET
+  )
+
+message(STATUS "Remote - FETCH_FROM_URL ${FETCH_FROM_URL_PROJECT_NAME} [OK]")

--- a/FetchVTKExternalModule.cmake
+++ b/FetchVTKExternalModule.cmake
@@ -1,0 +1,21 @@
+include(FetchContent)
+
+set(proj VTKExternalModule)
+if (FETCH_${proj}_INSTALL_LOCATION)
+  # The install location can be specified
+  set(EP_SOURCE_DIR "${FETCH_${proj}_INSTALL_LOCATION}")
+else()
+  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
+endif()
+
+FetchContent_Populate(${proj}
+  SOURCE_DIR     ${EP_SOURCE_DIR}
+  GIT_REPOSITORY https://github.com/jcfr/VTKExternalModule.git
+  GIT_TAG        d6445b187e1b07e7e902810920b954f9cc2cf727
+  QUIET
+  )
+
+message(STATUS "Remote - ${proj} [OK]")
+
+set(VTKExternalModule_SOURCE_DIR ${EP_SOURCE_DIR})
+message(STATUS "Remote - VTKExternalModule_SOURCE_DIR:${VTKExternalModule_SOURCE_DIR}")

--- a/SuperBuild/External_CLEAVER.cmake
+++ b/SuperBuild/External_CLEAVER.cmake
@@ -1,0 +1,75 @@
+
+set(proj CLEAVER)
+
+# Set dependency list
+set(${proj}_DEPENDENCIES "")
+
+# Include dependent projects if any
+ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
+
+# Sanity checks
+if(DEFINED ${proj}_INCLUDE_DIR AND NOT EXISTS ${${proj}_INCLUDE_DIR})
+  message(FATAL_ERROR "${proj}_INCLUDE_DIR variable is defined but corresponds to nonexistent directory")
+endif()
+if(DEFINED ${proj}_LIBRARY AND NOT EXISTS ${${proj}_LIBRARY})
+  message(FATAL_ERROR "${proj}_LIBRARY variable is defined but corresponds to nonexistent file")
+endif()
+
+if(NOT DEFINED ${proj}_INCLUDE_DIR OR NOT DEFINED ${proj}_LIBRARY)
+
+  set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS )
+
+  if(NOT CMAKE_CONFIGURATION_TYPES)
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+      -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+      )
+  endif()
+
+  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+
+  ExternalProject_add(${proj}
+    GIT_REPOSITORY https://github.com/SCIInstitute/Cleaver2.git
+    GIT_TAG bb1d7e0604171b52f4e2f3b64178860dde0e4a58
+    SOURCE_DIR ${EP_SOURCE_DIR}
+    BINARY_DIR ${EP_BINARY_DIR}
+    CMAKE_CACHE_ARGS
+      # Options
+      -DBUILD_CLI:BOOL=OFF
+      -DBUILD_EXTRAS:BOOL=OFF
+      -DBUILD_GUI:BOOL=OFF
+      -DBUILD_SHARED_LIBS:BOOL=OFF
+      -DBUILD_TESTING:BOOL=OFF
+      -DTeem_BZIP2:BOOL=OFF
+      -DUSE_GCOV:BOOL=OFF
+      -DUSE_ITK:BOOL=OFF
+      -DCOPY_HEADER_FILES:BOOL=ON
+      # Install directories
+      # NA
+      ${EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS}
+    INSTALL_COMMAND ""
+    USES_TERMINAL_DOWNLOAD 1
+    USES_TERMINAL_UPDATE 1
+    USES_TERMINAL_CONFIGURE 1
+    USES_TERMINAL_BUILD 1
+    USES_TERMINAL_INSTALL 1
+    )
+
+  set(${proj}_INCLUDE_DIR ${EP_BINARY_DIR}/include)
+
+  if(WIN32)
+    set(${proj}_LIBRARY ${EP_BINARY_DIR}/lib/libcleaver.lib)
+  else()
+    set(${proj}_LIBRARY ${EP_BINARY_DIR}/lib/libcleaver.a)
+  endif()
+
+endif()
+
+mark_as_superbuild(
+  VARS
+    ${proj}_INCLUDE_DIR:PATH
+    ${proj}_LIBRARY:FILEPATH
+  )
+
+ExternalProject_Message(${proj} "${proj}_INCLUDE_DIR:${${proj}_INCLUDE_DIR}")
+ExternalProject_Message(${proj} "${proj}_LIBRARY:${${proj}_LIBRARY}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = [
+  "cmake",
+  "ninja",
+  "scikit-build",
+  "setuptools>=42",
+  "wheel",
+  "setuptools_scm[toml]>=6.2",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,200 @@
+import os
+from pathlib import Path
+import platform
+import shutil
+import subprocess
+import sys
+
+from skbuild import setup
+
+
+vtk_module_source_dir = Path(__file__).parent.resolve()
+
+
+def auto_download_vtk_wheel_sdk():
+    # Automatically download the VTK wheel SDK based upon the current platform
+    # and python version.
+    # If the download location changes, we may need to change the logic here.
+    # Returns the path to the unpacked SDK.
+
+    base_url = "https://vtk.org/files/wheel-sdks/"
+    prefix = "vtk-wheel-sdk"
+    default_sdk_version = "9.2.5"
+    # The user can set the sdk version via an environment variable
+    sdk_version = os.getenv("VTK_WHEEL_SDK_VERSION", default_sdk_version)
+    py_version_short = "".join(map(str, sys.version_info[:2]))
+
+    py_version = f"cp{py_version_short}-cp{py_version_short}"
+    if sys.version_info[:2] < (3, 8):
+        # Need to add "m" at the end
+        py_version += "m"
+
+    platform_suffixes = {
+        "linux": "manylinux_2_17_x86_64.manylinux2014_x86_64",
+        "darwin": "macosx_10_10_x86_64",
+        "win32": "win_amd64",
+    }
+
+    if sys.platform not in platform_suffixes:
+        raise NotImplementedError(sys.platform)
+
+    platform_suffix = platform_suffixes[sys.platform]
+
+    if sys.platform == "darwin":
+        is_arm = (
+            platform.machine() == "arm64" or
+            # ARCHFLAGS: see https://github.com/pypa/cibuildwheel/discussions/997
+            os.getenv("ARCHFLAGS") == "-arch arm64"
+        )
+        if is_arm:
+            # It's an arm64 build
+            platform_suffix = "macosx_11_0_arm64"
+
+    dir_name = f"{prefix}-{sdk_version}-{py_version}-{platform_suffix}"
+    default_install_path = Path(".").resolve() / f"_deps/{dir_name}"
+    install_path = Path(os.getenv("VTK_WHEEL_SDK_INSTALL_PATH",
+                                  default_install_path))
+
+    if install_path.exists():
+        # It already exists, just return it
+        return install_path.as_posix()
+
+    # Need to download it
+    full_name = f"{prefix}-{sdk_version}-{py_version}-{platform_suffix}.tar.xz"
+    url = f"{base_url}{full_name}"
+
+    script_path = str(vtk_module_source_dir /
+                      "FetchFromUrl.cmake")
+
+    cmd = [
+        "cmake",
+        f"-DFETCH_FROM_URL_PROJECT_NAME={prefix}",
+        f"-DFETCH_FROM_URL_INSTALL_LOCATION={install_path.as_posix()}",
+        f"-DFETCH_FROM_URL_URL={url}",
+        "-P", script_path,
+    ]
+    subprocess.check_call(cmd)
+
+    return install_path.as_posix()
+
+
+def auto_download_vtk_external_module():
+    # Automatically download the VTKExternalModule repository.
+    # Returns the path to the VTKExternalModule directory.
+
+    external_module_path = Path(".").resolve() / "_deps/VTKExternalModule"
+    if external_module_path.exists():
+        # It must have already been downloaded. Just return it.
+        return external_module_path.as_posix()
+
+    # Run the script to download it
+    script_path = str(vtk_module_source_dir /
+                      "FetchVTKExternalModule.cmake")
+    cmd = [
+        "cmake",
+        "-DFETCH_VTKExternalModule_INSTALL_LOCATION=" +
+        external_module_path.as_posix(),
+        "-P", script_path,
+    ]
+    subprocess.check_call(cmd)
+    return external_module_path.as_posix()
+
+
+vtk_wheel_sdk_path = os.getenv("VTK_WHEEL_SDK_PATH")
+if vtk_wheel_sdk_path is None:
+    vtk_wheel_sdk_path = auto_download_vtk_wheel_sdk()
+
+# Find the cmake dir
+cmake_glob = list(Path(vtk_wheel_sdk_path).glob("**/headers/cmake"))
+if len(cmake_glob) != 1:
+    raise Exception(f"Unable to find cmake directory in vtk_wheel_sdk_path [{vtk_wheel_sdk_path}]")
+
+vtk_wheel_sdk_cmake_path = cmake_glob[0]
+
+vtk_external_module_path = os.getenv("VTK_EXTERNAL_MODULE_PATH")
+if vtk_external_module_path is None:
+    # If it was not provided, clone it into a temporary directory
+    # Since we are using pyproject.toml, it will get removed automatically
+    vtk_external_module_path = auto_download_vtk_external_module()
+
+python3_executable = os.getenv("Python3_EXECUTABLE")
+if python3_executable is None:
+    python3_executable = shutil.which("python")
+
+if python3_executable is None:
+    msg = "Unable find python executable, please set Python3_EXECUTABLE"
+    raise Exception(msg)
+
+cmake_args = [
+    "-DVTK_MODULE_NAME:STRING=Cleaver",
+    f"-DVTK_MODULE_SOURCE_DIR:PATH={vtk_module_source_dir}",
+    f"-DVTK_MODULE_CMAKE_MODULE_PATH:PATH={vtk_wheel_sdk_cmake_path}",
+    "-DVTK_MODULE_SUPERBUILD:BOOL=ON",
+    "-DVTK_MODULE_EXTERNAL_PROJECT_DEPENDENCIES:STRING=CLEAVER",
+    "-DVTK_MODULE_EXTERNAL_PROJECT_CMAKE_CACHE_ARGS:STRING=VTK_USE_X;VTK_USE_COCOA",
+    f"-DVTK_DIR:PATH={vtk_wheel_sdk_cmake_path}",
+    "-DCMAKE_INSTALL_LIBDIR:STRING=lib",
+    f"-DPython3_EXECUTABLE:FILEPATH={python3_executable}",
+    "-DVTK_WHEEL_BUILD:BOOL=ON",
+    "-S", vtk_external_module_path,
+]
+
+if sys.platform == "linux":
+    # We currently have to add this for the render window to get compiled
+    cmake_args.append("-DVTK_USE_X:BOOL=ON")
+
+    if os.getenv("LINUX_VTK_CLEAVER_USE_COMPATIBLE_ABI") == "1":
+        # If building locally, it is necessary to set this in order to
+        # produce a wheel that can be used. Otherwise, the VTK symbols
+        # will not match those in the actual VTK wheel.
+        cmake_args.append("-DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0")
+
+elif sys.platform == "darwin":
+    # We currently have to add this for the render window to get compiled
+    cmake_args.append("-DVTK_USE_COCOA:BOOL=ON")
+
+    if os.getenv("ARCHFLAGS") == "-arch arm64":
+        # We are cross-compiling and need to set CMAKE_SYSTEM_NAME as well.
+        # NOTE: we haven"t actually succeeded in cross-compiling this module.
+        cmake_args.append("-DCMAKE_SYSTEM_NAME=Darwin")
+
+long_description = (vtk_module_source_dir / "README.md").read_text(encoding="utf-8")
+
+setup(
+    name="vtk-cleaver",
+    description="A VTK interface to the Cleaver multi-material tetrahedral meshing library",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/SCIInstitute/VTKCleaver",
+    author="SCI Institute",
+    email="vtk+support@discourse.vtk.org",
+    license="MIT License",
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: C++",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Education",
+        "Intended Audience :: Healthcare Industry",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Medical Science Apps.",
+        "Topic :: Scientific/Engineering :: Information Analysis",
+        "Topic :: Software Development :: Libraries",
+        "Operating System :: Linux",
+        "Operating System :: MacOS",
+        "Operating System :: Microsoft :: Windows",
+    ],
+    keywords="",
+    packages=["vtkmodules"],
+    package_dir={
+        "vtkmodules": "lib/vtkmodules",
+    },
+    cmake_args=cmake_args,
+    install_requires=["vtk==9.2.5"],
+    project_urls={  # Optional
+        "Bug Reports": "https://github.com/SCIInstitute/VTKCleaver/issues",
+        "Source": "https://github.com/SCIInstitute/VTKCleaver/",
+    },
+)


### PR DESCRIPTION
The scripts were copied from ClinicalGraphics/VTKU3DExporter@669fe64bc (originally adapted from Kitware/LookingGlassVTKModule@78cc2cec9 and Slicer/vtkAddon@38c95af85)

Add CLEAVER external project for statically building the Cleaver library.